### PR TITLE
SPORT-288: Prevent `django-auth-adfs` from deletion custom groups

### DIFF
--- a/adminpage/Dockerfile
+++ b/adminpage/Dockerfile
@@ -5,5 +5,9 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /src
 WORKDIR /src
 COPY ./requirements.txt /src/
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install -r /src/requirements.txt
 COPY . /src

--- a/adminpage/adminpage/settings.py
+++ b/adminpage/adminpage/settings.py
@@ -184,6 +184,7 @@ AUTH_ADFS = {
     "USERNAME_CLAIM": "upn",
     # use group ids instead of name, because names are written in different languages
     "GROUPS_CLAIM": "groupsid",
+    "GROUPS_CLAIM_REGEX": r"S-\d*-\d*-\d*-\d*-\d*-\d*-\d*",
     "MIRROR_GROUPS": True,
     "CLAIM_MAPPING": {
         "first_name": "given_name",

--- a/adminpage/requirements.txt
+++ b/adminpage/requirements.txt
@@ -1,6 +1,6 @@
 Django==3.1.8
 django-admin-autocomplete-filter==0.5
-django-auth-adfs==1.3.1
+git+https://github.com/InnopolisSport/django-auth-adfs.git@1.3.1r#egg=django-auth-adfs
 djangorestframework==3.11.2
 drf-yasg==1.17.1
 openpyxl==3.0.3


### PR DESCRIPTION
Use our fork of library. Changes: https://github.com/InnopolisSport/django-auth-adfs/compare/1.3.1...1.3.1r